### PR TITLE
Make pip_import more verbose

### DIFF
--- a/python/pip.bzl
+++ b/python/pip.bzl
@@ -34,7 +34,7 @@ def _pip_import_impl(repository_ctx):
   cmd = cmd + [a for args in extra_cmd for a in args]
   if repository_ctx.attr.requirements_fix:
       cmd += ["--input-fix", repository_ctx.path(repository_ctx.attr.requirements_fix)]
-  result = repository_ctx.execute(cmd)
+  result = repository_ctx.execute(cmd, quiet=False)
 
   if result.return_code:
     fail("pip_import failed: %s (%s)" % (result.stdout, result.stderr))


### PR DESCRIPTION
Don't supress output from piptool.par.  This allows users to see
what bazel is doing when it appears stuck while downloading wheels.

While the output is a bit on the spammy side now, the common case
where the pips are already up-to-date will be completely silent
(of course).  Also, the more pressing problem is that people will
just kill bazel/dazel when they think it's stuck - being too spammy
is much less of a real problem.